### PR TITLE
Fix line number issue when using GitHub formatter

### DIFF
--- a/pronto-rails_migrations.gemspec
+++ b/pronto-rails_migrations.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "pronto-rails_migrations"
-  spec.version       = '0.10.1'
+  spec.version       = '0.10.2'
   spec.authors       = ["Tomas Varneckas"]
   spec.email         = ["t.varneckas@gmail.com"]
 


### PR DESCRIPTION
Looks like at some version of `pronto` or something related it became not possible to add comments on a file without specifying a line.

For simplicity sake I'm using the first line of relevant patch added lines.

@raimondasv @vitiokss