### PR TITLE
Fix crash when bad_structure_sql_messages method returns early

### DIFF
--- a/lib/pronto/rails_migrations.rb
+++ b/lib/pronto/rails_migrations.rb
@@ -32,7 +32,7 @@ module Pronto
 
     def bad_structure_sql_messages
       patch = structure_sql_patches.first
-      return false unless patch
+      return [] unless patch
 
       structure_sql = File.read(patch.new_file_full_path)
       inserts = structure_sql.split("\n").grep(/\('\d+'\)/)

--- a/pronto-rails_migrations.gemspec
+++ b/pronto-rails_migrations.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "pronto-rails_migrations"
-  spec.version       = '0.10.2'
+  spec.version       = '0.10.3'
   spec.authors       = ["Tomas Varneckas"]
   spec.email         = ["t.varneckas@gmail.com"]
 


### PR DESCRIPTION
The method should always return an array. In this case it returned `false` when attempting to halt early and this does not work with code outside of it.

@vitiokss