### PR TITLE
Fix mismatches superclass issue when version file is loaded first

### DIFF
--- a/lib/pronto/rails_migrations/version.rb
+++ b/lib/pronto/rails_migrations/version.rb
@@ -1,0 +1,3 @@
+module Pronto
+  RAILS_MIGRATIONS_VERSION = '0.11.0'
+end

--- a/lib/pronto/version.rb
+++ b/lib/pronto/version.rb
@@ -1,5 +1,0 @@
-module Pronto
-  class RailsMigrations
-    VERSION = '0.10.4'
-  end
-end

--- a/pronto-rails_migrations.gemspec
+++ b/pronto-rails_migrations.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'pronto/version'
+require 'pronto/rails_migrations/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "pronto-rails_migrations"
-  spec.version       = Pronto::RailsMigrations::VERSION
+  spec.version       = Pronto::RAILS_MIGRATIONS_VERSION
   spec.authors       = ["Vinted"]
   spec.email         = ["backend@vinted.com"]
 


### PR DESCRIPTION
At some point loading order changed maybe due to bundler version changes and the version file was loaded first and defined the `Pronto::RailsMigrations` class as a class with no parent. This caused the actual runner definition to clash with that.

With this chaneg we avoid the problem by not using the same constant.