### PR TITLE
Make checks stricter

### DIFF
--- a/lib/pronto/rails_migrations.rb
+++ b/lib/pronto/rails_migrations.rb
@@ -9,7 +9,8 @@ module Pronto
         patch = migration_patches.first
         messages << message(
           patch,
-          'Run migrations in a separate PR from application code changes.'
+          'Run migrations in a separate PR from application code changes.',
+          level: :warning
         )
       end
 
@@ -63,10 +64,10 @@ module Pronto
       messages
     end
 
-    def message(patch, text)
+    def message(patch, text, level: :error)
       path = patch.delta.new_file[:path]
       line = patch.added_lines.first
-      Message.new(path, line, :warning, text, nil, self.class)
+      Message.new(path, line, level, text, nil, self.class)
     end
 
     def structure_sql_patches

--- a/lib/pronto/rails_migrations/version.rb
+++ b/lib/pronto/rails_migrations/version.rb
@@ -1,3 +1,3 @@
 module Pronto
-  RAILS_MIGRATIONS_VERSION = '0.11.1'
+  RAILS_MIGRATIONS_VERSION = '0.12.0'
 end


### PR DESCRIPTION
Messed up `db/structure.sql` is disruptive for all developers, therefore
let's make it error level. Separating code changes and migration PRs remains warning as it's not as disruptive.

I don't like how hardcoded these things are right now. I think it would make sense to rewrite this gem as rubocop extensions, with each check being a rubocop cop, then we would have the flexibility to tune error levels from the project itself.