### PR TITLE
Make release pipeline use ruby 3.0.4

### DIFF
--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         run: |
-          apt-get update -y && apt-get install -y --no-install-recommends cmake=3.13.4-1
+          apt-get update -y && apt-get install -y --no-install-recommends
           gem install bundler
           bundle install
 

--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -1,7 +1,7 @@
 name: Build and release ruby gem
 
 on:
-  pull_request: 
+  pull_request:
     branches: [ master ]
   push:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
 jobs:
   build-release-pipeline:
     runs-on: ubuntu-latest
-    container: ruby:2.7.2
+    container: ruby:3.0.4
     steps:
       - uses: actions/checkout@v2
       - name: Setup

--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         run: |
-          apt-get update -y && apt-get install -y --no-install-recommends
+          apt-get update -y && apt-get install -y --no-install-recommends cmake
           gem install bundler
           bundle install
 


### PR DESCRIPTION
Pipelines failing, aligning ruby versions. Not updating, because I don't want to break things just yet

@vinted/backend-technologies 