### PR TITLE
Adjust checks to changes in rails 7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pronto-rails_migrations (0.14.4)
+    pronto-rails_migrations (0.15.0)
       faraday (>= 1.10.3)
       multipart-post (>= 2.1.1)
       pronto (>= 0.11.1)

--- a/lib/pronto/rails_migrations.rb
+++ b/lib/pronto/rails_migrations.rb
@@ -37,12 +37,12 @@ module Pronto
 
       structure_sql = File.read(patch.new_file_full_path)
       inserts = structure_sql.split("\n").grep(/\('\d+'\)/)
-      unordered_inserts = (inserts.sort != inserts)
+      unordered_inserts = (inserts.sort.reverse != inserts)
 
       *all_but_tail, tail = inserts
       bad_semicolons = all_but_tail.any? { |line| line.end_with?(';') } || !tail.end_with?(';')
 
-      bad_ending = structure_sql[-4, 4] !~ /[^\n]\n\n\n/
+      bad_ending = structure_sql[-2, 2] !~ /[^\n]\n/
 
       messages = []
 
@@ -59,7 +59,7 @@ module Pronto
           'last insert must end with semicolon (`;`).'
         )
       end
-      messages << message(patch, '`db/structure.sql` must end with 2 empty lines.') if bad_ending
+      messages << message(patch, '`db/structure.sql` must end without extra empty lines.') if bad_ending
 
       messages
     end

--- a/lib/pronto/rails_migrations/version.rb
+++ b/lib/pronto/rails_migrations/version.rb
@@ -1,3 +1,3 @@
 module Pronto
-  RAILS_MIGRATIONS_VERSION = '0.14.4'
+  RAILS_MIGRATIONS_VERSION = '0.15.0'
 end


### PR DESCRIPTION
Rails 7.1 introduced these changes in structure.sql file generation: https://github.com/rails/rails/pull/44363 & https://github.com/rails/rails/pull/46454. Now we receive pronto warnings about bad style in structure.sql

Question: can we go forward without supporting previous version? 
We still have some services in Vinted on rails <7.1: not sure how long it will take for others to upgrade

Thanks!

@vinted/platform-backend @vinted/backend-technologies 
