### PR TITLE
Fix structure.sql end newline check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pronto-rails_migrations (0.15.0)
+    pronto-rails_migrations (0.16.0)
       faraday (>= 1.10.3)
       multipart-post (>= 2.1.1)
       pronto (>= 0.11.1)

--- a/lib/pronto/rails_migrations.rb
+++ b/lib/pronto/rails_migrations.rb
@@ -42,7 +42,7 @@ module Pronto
       *all_but_tail, tail = inserts
       bad_semicolons = all_but_tail.any? { |line| line.end_with?(';') } || !tail.end_with?(';')
 
-      bad_ending = structure_sql[-2, 2] !~ /[^\n]\n/
+      bad_ending = structure_sql[-4, 4] !~ /[^\n]\n\n\n/
 
       messages = []
 
@@ -59,7 +59,7 @@ module Pronto
           'last insert must end with semicolon (`;`).'
         )
       end
-      messages << message(patch, '`db/structure.sql` must end without extra empty lines.') if bad_ending
+      messages << message(patch, '`db/structure.sql` must end with 2 empty lines.') if bad_ending
 
       messages
     end

--- a/lib/pronto/rails_migrations/version.rb
+++ b/lib/pronto/rails_migrations/version.rb
@@ -1,3 +1,3 @@
 module Pronto
-  RAILS_MIGRATIONS_VERSION = '0.15.0'
+  RAILS_MIGRATIONS_VERSION = '0.16.0'
 end


### PR DESCRIPTION
Should check if there are exactly two newlines at the end of the structure.sql file. Two lines at the end are standard.

@vinted/rududu 